### PR TITLE
Add "Open with Codeanywhere" badge to README.md

### DIFF
--- a/garlic-astro/README.md
+++ b/garlic-astro/README.md
@@ -9,7 +9,7 @@ npm create astro@latest -- --template component
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/non-html-pages)
 [![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/non-html-pages)
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/component/devcontainer.json)
-
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/withastro/astro?devcontainer_path=.devcontainer/component/devcontainer.json)
 
 ## 🚀 Project Structure
 


### PR DESCRIPTION
## Why?

With Codeanywhere, devs and contributors can:

- Instantly launch a cloud or local IDE with remote dev environment.
- Automatically set up and configure a remote dev environments if a devcontainer.json file is present.

**Benefits:**

1. Faster onboarding for new contributors.
2. Consistent and ready-to-use development environments.
3. Flexibility to work in the cloud or locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new "Open in Codeanywhere" badge to the project README, providing an additional development environment option for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->